### PR TITLE
fix: control icons dont appear

### DIFF
--- a/src/support.tsx
+++ b/src/support.tsx
@@ -65,7 +65,7 @@ after(() => {
     const $ = Cypress.$
 
     const findParentTitles = (rt, title = []) => {
-      title.push(rt.textContent)
+      title.push(rt.firstChild.textContent)
 
       const $parent = $(rt).parents('li.suite')
 


### PR DESCRIPTION
Field `textContent` of elements with class `runnable-title` equals to test title concatenated with pass status

![image](https://user-images.githubusercontent.com/2546209/58693825-45c12980-839a-11e9-9bc0-85679eb74b5f.png)

By the way, is there a way to make assertions against command panel ui? 
```js
cy.get('.only-skip)
```